### PR TITLE
Change $scopeSeparator to a space in BitbucketProvider

### DIFF
--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -13,6 +13,13 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
      * @var array
      */
     protected $scopes = ['email'];
+    
+    /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
In Bitbucket's implementation of OAuth2, the space character is the delimiter for scopes.

When trying to request multiple scopes, the request fails with the callback url having `error_description` appended to it with the value of 'Unknown scope: ', and then a comma-delimited list of scopes.  After that the listed `error` variable has a value of 'invalid_scope'.